### PR TITLE
[README.md] Use asyncio.run 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ async def main():
     await client.bulk_upsert_application_commands(payload, guild_id=942837947315662859)
     await client.close()
     
-loop = asyncio.get_event_loop()
-loop.run_until_complete(main())
+asyncio.run(main())
 ```
 
 You may think this is quite verbose for a HTTP client, however, the fuwa eco-system doesn't expect you to usue this on its own. This package is used heavily within the `command-framework`. The package import (`from fuwa.fhttp`) is `fhttp` due to the `http` python standard library. This is to avoid any shadowing issues internally and for you.


### PR DESCRIPTION
`asyncio.run` was introduced in python 3.7. Since min requirement is python 3.8, it's better to use `asyncio.run`